### PR TITLE
Update plugin-system/starter to make main() compile

### DIFF
--- a/challenges/plugin-system/src/starter.rs
+++ b/challenges/plugin-system/src/starter.rs
@@ -10,7 +10,25 @@ pub struct PluginManager {
 // 3. Implement the PluginManager
 impl PluginManager {}
 
+
 // Example usage
+pub struct MyPlugin;
+
+impl Plugin for MyPlugin {
+    fn name(&self) -> &str {
+        "MyPlugin"
+    }
+    fn execute(&self) {
+        println!("Executing MyPlugin");
+    }
+}
+
+impl MyPlugin {
+    fn new() -> Self {
+        Self
+    }
+}
+
 pub fn main() {
     let mut manager = PluginManager::new();
 


### PR DESCRIPTION
The plugin-system starter main() will not compile, due to the missing MyPlugin struct. It is not part of the task description to add this. Added it, to still show example usage without compiler error.